### PR TITLE
explicitly locate the builtin_interfaces__rosidl_generator_c library

### DIFF
--- a/cyclonedds_ws/src/unitree/unitree_api/CMakeLists.txt
+++ b/cyclonedds_ws/src/unitree/unitree_api/CMakeLists.txt
@@ -16,6 +16,14 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # find dependencies
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  find_library(
+    builtin_interfaces__rosidl_generator_c_LIB NAMES builtin_interfaces__rosidl_generator_c
+    PATHS "/opt/ros/$ENV{ROS_DISTRO}/lib"
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH REQUIRED
+  )
+endif()
+
 find_package(ament_cmake REQUIRED)
 # uncomment the following section in order to fill in
 # further dependencies manually.

--- a/cyclonedds_ws/src/unitree/unitree_go/CMakeLists.txt
+++ b/cyclonedds_ws/src/unitree/unitree_go/CMakeLists.txt
@@ -16,6 +16,14 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # find dependencies
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  find_library(
+    builtin_interfaces__rosidl_generator_c_LIB NAMES builtin_interfaces__rosidl_generator_c
+    PATHS "/opt/ros/$ENV{ROS_DISTRO}/lib"
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH REQUIRED
+  )
+endif()
+
 find_package(ament_cmake REQUIRED)
 # uncomment the following section in order to fill in
 # further dependencies manually.

--- a/cyclonedds_ws/src/unitree/unitree_hg/CMakeLists.txt
+++ b/cyclonedds_ws/src/unitree/unitree_hg/CMakeLists.txt
@@ -16,6 +16,14 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # find dependencies
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  find_library(
+    builtin_interfaces__rosidl_generator_c_LIB NAMES builtin_interfaces__rosidl_generator_c
+    PATHS "/opt/ros/$ENV{ROS_DISTRO}/lib"
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH REQUIRED
+  )
+endif()
+
 find_package(ament_cmake REQUIRED)
 # uncomment the following section in order to fill in
 # further dependencies manually.


### PR DESCRIPTION
When building the library in cross-compiling CI over ROS Humble there is an issue with the libraries:

```
82.19 Starting >>> unitree_api
82.26 Starting >>> unitree_go
82.30 Starting >>> unitree_hg
97.31 --- stderr: unitree_api
97.31 CMake Error at /opt/ros/humble/share/builtin_interfaces/cmake/ament_cmake_export_libraries-extras.cmake:48 (message):
97.31   Package 'builtin_interfaces' exports the library
97.31   'builtin_interfaces__rosidl_generator_c' which couldn't be found
97.31 Call Stack (most recent call first):
97.31   /opt/ros/humble/share/builtin_interfaces/cmake/builtin_interfacesConfig.cmake:41 (include)
97.31   /opt/ros/humble/share/std_msgs/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package)
97.31   /opt/ros/humble/share/std_msgs/cmake/std_msgsConfig.cmake:41 (include)
97.31   /opt/ros/humble/share/geometry_msgs/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package)
97.31   /opt/ros/humble/share/geometry_msgs/cmake/geometry_msgsConfig.cmake:41 (include)
97.31   CMakeLists.txt:24 (find_package)
97.31 
97.31 
97.31 ---
97.32 Failed   <<< unitree_api [15.1s, exited with code 1]
97.33 Aborted  <<< unitree_go [15.0s]
115.0 Aborted  <<< unitree_hg [32.7s]
115.2 
115.2 Summary: 0 packages finished [35.2s]
115.2   1 package failed: unitree_api
115.2   2 packages aborted: unitree_go unitree_hg
115.2   3 packages had stderr output: unitree_api unitree_go unitree_hg
------
```


This is a know issue: https://github.com/introlab/rtabmap_ros/issues/1288 
and the same fix is applied to this library.