### PR TITLE
add rosidl_generator_dds_idl dependency to package.xml

### DIFF
--- a/cyclonedds_ws/src/unitree/unitree_api/package.xml
+++ b/cyclonedds_ws/src/unitree/unitree_api/package.xml
@@ -5,12 +5,14 @@
   <version>0.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="unitree@unitree.com">Unitree</maintainer>
-<license>BSD 3-Clause License</license>
-  
+  <license>BSD 3-Clause License</license>
+
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rosidl_generator_dds_idl</build_depend>
 
   <depend>geometry_msgs</depend>
 

--- a/cyclonedds_ws/src/unitree/unitree_go/package.xml
+++ b/cyclonedds_ws/src/unitree/unitree_go/package.xml
@@ -5,12 +5,14 @@
   <version>0.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="unitree@unitree.com">Unitree</maintainer>
-<license>BSD 3-Clause License</license>
-  
+  <license>BSD 3-Clause License</license>
+
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rosidl_generator_dds_idl</build_depend>
 
   <depend>geometry_msgs</depend>
 

--- a/cyclonedds_ws/src/unitree/unitree_hg/package.xml
+++ b/cyclonedds_ws/src/unitree/unitree_hg/package.xml
@@ -5,12 +5,14 @@
   <version>0.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="unitree@unitree.com">Unitree</maintainer>
-<license>BSD 3-Clause License</license>
-  
+  <license>BSD 3-Clause License</license>
+
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rosidl_generator_dds_idl</build_depend>
 
   <depend>geometry_msgs</depend>
 


### PR DESCRIPTION
This allows rosidl_generator_dds_idl to be installed with ``rosdep``, the common way to install dependencies. Without it, users may encounter this error

```sh
--- stderr: unitree_api
CMake Error at CMakeLists.txt:26 (find_package):
  By not providing "Findrosidl_generator_dds_idl.cmake" in CMAKE_MODULE_PATH
  this project has asked CMake to find a package configuration file provided
  by "rosidl_generator_dds_idl", but CMake did not find one.
  Could not find a package configuration file provided by
  "rosidl_generator_dds_idl" with any of the following names:
    rosidl_generator_dds_idlConfig.cmake
    rosidl_generator_dds_idl-config.cmake
  Add the installation prefix of "rosidl_generator_dds_idl" to
  CMAKE_PREFIX_PATH or set "rosidl_generator_dds_idl_DIR" to a directory
  containing one of the above files.  If "rosidl_generator_dds_idl" provides
  a separate development package or SDK, be sure it has been installed.
---
Failed   <<< unitree_api [1.39s, exited with code 1]
```