### PR TITLE
Add SportModeState.msg to unitree_hg for sport mode state handling

### DIFF
--- a/cyclonedds_ws/src/unitree/unitree_hg/CMakeLists.txt
+++ b/cyclonedds_ws/src/unitree/unitree_hg/CMakeLists.txt
@@ -37,6 +37,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 	"msg/MotorCmd.msg"
 	"msg/MotorState.msg"
 	"msg/PressSensorState.msg"
+	"msg/SportModeState.msg"
   DEPENDENCIES geometry_msgs
 )
 

--- a/cyclonedds_ws/src/unitree/unitree_hg/msg/SportModeState.msg
+++ b/cyclonedds_ws/src/unitree/unitree_hg/msg/SportModeState.msg
@@ -1,0 +1,4 @@
+uint32 fsm_id
+uint32 fsm_mode
+uint32 task_id
+float32 task_time


### PR DESCRIPTION
### Summary
This PR adds the missing `SportModeState` message to the `unitree_hg` package.  
The message definition is based on the IDL specification provided in [unitree_sdk2](https://github.com/unitreerobotics/unitree_sdk2/blob/main/include/unitree/idl/hg/SportModeState_.hpp).

### Changes
- **Added** `unitree_hg/msg/SportModeState.msg`
- **Updated** `CMakeLists.txt` to generate the message interface
- **Updated** `package.xml` to include necessary dependencies

### Motivation
The `unitree_hg/SportModeState` message exists in `unitree_sdk2`, but was not available in `unitree_ros2`.  
This PR makes it accessible in ROS 2 environments, enabling users to handle sport mode state data directly through ROS 2 interfaces.

### Verification
After building the workspace:

```bash
colcon build --packages-select unitree_hg
source install/setup.bash
ros2 interface show unitree_hg/msg/SportModeState
```
Result:
```bash
uint32 fsm_id
uint32 fsm_mode
uint32 task_id
float32 task_time
```

## Notes
* Tested on ROS 2 Humble
* Backward compatibility is not affected
